### PR TITLE
Refactor internals to use linked list & support SparseString embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,4 +190,4 @@ Results:
 | PlainArray     | 89.3 +- 1.1     | 2.02                     |
 | PlainArray2    | 60.7 +- 2.8     | 1.90                     |
 
-For additional microbenchmarks, see [benchmark_results.md](./benchmark_results.md), which reports the time to perform 1,000,000 operations of various types (implemented in [benchmarks/traces.ts](./benchmarks/traces.ts)).
+For additional microbenchmarks, see [benchmark_results.txt](./benchmark_results.txt), which reports the time to perform 1,000,000 operations of various types (implemented in [benchmarks/traces.ts](./benchmarks/traces.ts)).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For special cases, `SparseString` and `SparseIndices` implement the same functio
   but it uses strings (e.g. `"abc"`) instead of arrays (e.g. `["a", "b", "c"]`) in its internal state
   and serialized form.
   This typically uses less memory (2x in our benchmarks) and results in smaller JSON,
-  though with a slight cost in mutation speed.
+  though with a slight cost in mutation speed. `SparseString<E>` can also contain embedded objects of type `E` (e.g., an image in a text document), each taking the place of one char.
 - `SparseIndices` is functionally identical to a `SparseArray`, except that
   it only stores which indices are present, not their associated values.
   This typically uses much less memory (4x in our benchmarks) and results in much smaller JSON.
@@ -90,9 +90,6 @@ arr2.set(6, "h");
 
 // Total present values.
 arr2.count(); // 4
-
-// Present values within a given slice.
-arr2.countBetween(0, 4); // 2
 
 // Present values up to but excluding a given index, plus whether that index is present.
 arr2.countAt(4); // 2

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ console.log(previous.length); // Prints 2 (last present index + 1) - not necessa
 
 The serialized form, `SerializedSparseArray<T>`, uses run-length encoded deletions. Specifically, it is an array that alternates between:
 
-- - arrays of present values, and
-- - numbers, representing that number of deleted values.
+- arrays of present values, and
+- numbers, representing that number of deleted values.
 
 For example:
 
@@ -165,11 +165,9 @@ Iterators (`entries`, `keys`, `newSlicer`) are invalidated by concurrent mutatio
 
 ## Internals
 
-Internally, the state of a `SparseArray<T>` as stored as an `Array<{ index: number, values: T[] }>`, indicating that a run of present `values` starts at `index`. These pairs are in order by `index` and always have deleted values in between them.
+Internally, the state of a `SparseArray<T>` as stored as a singly-linked list of nodes, where each node represents either an array of present values or a number of deleted values. The nodes are normalized so that they are never empty and adjacent nodes always have different types. In other words, a `SparseArray<T>`'s internal state is a singly-linked list representation of its serialized state.
 
-When the state can be represented as an ordinary `Array` - i.e., it is not sparse except for holes at the end - it may be stored as such. This saves some memory in our text-editing benchmarks, which create many (~10k) small sparse arrays, a decent fraction of which are not sparse.
-
-To reduce repetition and code size, most functionality for the three exported classes (`SparseArray`, `SparseString`, `SparseIndices`) is inherited from a common superclass, `SparseItems<I>`. It is a template class that defines mutations and queries in terms of "items" of type `I`, which represent a run of present values: `T[]` for `SparseArray`, `string` for `SparseString`, `number` for `SparseIndices`.
+To reduce repetition and code size, most functionality for the three exported classes (`SparseArray`, `SparseString`, `SparseIndices`) is inherited from a common superclass, `SparseItems<I>`. It is a template class that defines mutations and queries in terms of items of type `I`, which are the content of present nodes: `T[]` for `SparseArray`, `string` for `SparseString`, `number` for `SparseIndices`.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Iterators (`entries`, `keys`, `newSlicer`) are invalidated by concurrent mutatio
 
 ## Internals
 
-Internally, the state of a `SparseArray<T>` as stored as a singly-linked list of nodes, where each node represents either an array of present values or a number of deleted values. The nodes are normalized so that they are never empty and adjacent nodes always have different types. In other words, a `SparseArray<T>`'s internal state is a singly-linked list representation of its serialized state.
+Internally, the state of a `SparseArray<T>` as stored as a singly-linked list of nodes, where each node represents either an array of present values or a number of deleted values. The nodes are normalized so that they are never empty and adjacent nodes always have different types. In other words, a `SparseArray<T>`'s internal state is a singly-linked list representation of its serialized state. (Exception: The linked list may end with a deleted node, while the serialized state will not.)
 
 To reduce repetition and code size, most functionality for the three exported classes (`SparseArray`, `SparseString`, `SparseIndices`) is inherited from a common superclass, `SparseItems<I>`. It is a template class that defines mutations and queries in terms of items of type `I`, which are the content of present nodes: `T[]` for `SparseArray`, `string` for `SparseString`, `number` for `SparseIndices`.
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,11 @@ console.log(arr.length); // Prints 5
 Queries that only consider present values:
 
 ```ts
-const arr2 = SparseArray.fromEntries([
-  [0, "e"],
-  [1, "f"],
-  [5, "g"],
-  [6, "h"],
-]);
+const arr2 = SparseArray.new<string>();
+arr2.set(0, "e");
+arr2.set(1, "f");
+arr2.set(5, "g");
+arr2.set(6, "h");
 
 // Total present values.
 arr2.count(); // 4
@@ -141,12 +140,12 @@ The serialized form, `SerializedSparseArray<T>`, uses run-length encoded deletio
 For example:
 
 ```ts
-const arr4 = SparseArray.fromEntries([
-  [0, "foo"],
-  [1, "bar"],
-  [5, "X"],
-  [6, "yy"],
-]);
+const arr4 = SparseArray.new<string>();
+arr4.set(0, "foo");
+arr4.set(1, "bar");
+arr4.set(5, "X");
+arr4.set(6, "yy");
+
 console.log(arr4.serialize()); // Prints [['foo', 'bar'], 3, ['X', 'yy']]
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ arr.has(0); // false
 // Length is the last present index + 1 (or 0 if empty).
 console.log(arr.length); // Prints 5
 // Note: All methods accept index arguments `>= this.length`, acting as if
-// the array ends with infinitely many holes.
+// the array ends with infinitely many deleted indices (empty slots).
 ```
 
 Queries that only consider present values:
@@ -130,7 +130,7 @@ console.log(previous.length); // Prints 2 (last present index + 1) - not necessa
 The serialized form, `SerializedSparseArray<T>`, uses run-length encoded deletions. Specifically, it is an array that alternates between:
 
 - arrays of present values, and
-- numbers, representing that number of deleted values.
+- numbers, representing that number of deleted indices (empty slots).
 
 For example:
 
@@ -162,7 +162,7 @@ Iterators (`entries`, `keys`, `newSlicer`) are invalidated by concurrent mutatio
 
 ## Internals
 
-Internally, the state of a `SparseArray<T>` as stored as a singly-linked list of nodes, where each node represents either an array of present values or a number of deleted values. The nodes are normalized so that they are never empty and adjacent nodes always have different types. In other words, a `SparseArray<T>`'s internal state is a singly-linked list representation of its serialized state. (Exception: The linked list may end with a deleted node, while the serialized state will not.)
+Internally, the state of a `SparseArray<T>` as stored as a singly-linked list of nodes, where each node represents either an array of present values or a number of deleted indices. The nodes are normalized so that they are never empty and adjacent nodes always have different types. In other words, a `SparseArray<T>`'s internal state is a singly-linked list representation of its serialized state. (Exception: The linked list may end with a deleted node, while the serialized state will not.)
 
 To reduce repetition and code size, most functionality for the three exported classes (`SparseArray`, `SparseString`, `SparseIndices`) is inherited from a common superclass, `SparseItems<I>`. It is a template class that defines mutations and queries in terms of items of type `I`, which are the content of present nodes: `T[]` for `SparseArray`, `string` for `SparseString`, `number` for `SparseIndices`.
 

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ Results:
 
 | Implementation | Total time (ms) | Ending memory usage (MB) |
 | -------------- | --------------- | ------------------------ |
-| SparseArray    | 59.3 +- 5.4     | 1.98                     |
-| SparseString   | 67.5 +- 9.5     | 1.13                     |
-| SparseIndices  | 53.2 +- 1.5     | 0.48                     |
-| PlainArray     | 89.3 +- 1.1     | 2.02                     |
-| PlainArray2    | 60.7 +- 2.8     | 1.90                     |
+| SparseArray    | 81.2 +- 9.0     | 1.91                     |
+| SparseString   | 80.9 +- 5.8     | 1.10                     |
+| SparseIndices  | 63.3 +- 7.5     | 0.47                     |
+| PlainArray     | 76.7 +- 10.5    | 2.02                     |
+| PlainArray2    | 51.8 +- 6.9     | 1.90                     |
 
 For additional microbenchmarks, see [benchmark_results.txt](./benchmark_results.txt), which reports the time to perform 1,000,000 operations of various types (implemented in [benchmarks/traces.ts](./benchmarks/traces.ts)).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For special cases, `SparseString` and `SparseIndices` implement the same functio
   but it uses strings (e.g. `"abc"`) instead of arrays (e.g. `["a", "b", "c"]`) in its internal state
   and serialized form.
   This typically uses less memory (2x in our benchmarks) and results in smaller JSON,
-  though with a slight cost in mutation speed. `SparseString<E>` can also contain embedded objects of type `E` (e.g., an image in a text document), each taking the place of one char.
+  though with a slight cost in mutation speed. `SparseString<E>` can also contain embedded objects of type `E` (e.g., an image inline in a text document), each taking the place of one char.
 - `SparseIndices` is functionally identical to a `SparseArray`, except that
   it only stores which indices are present, not their associated values.
   This typically uses much less memory (4x in our benchmarks) and results in much smaller JSON.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ For special cases, `SparseString` and `SparseIndices` implement the same functio
   it only stores which indices are present, not their associated values.
   This typically uses much less memory (4x in our benchmarks) and results in much smaller JSON.
 
-> **Disclaimer:** This library is still in alpha. I have unit & fuzz tested the core functionality, but not every edge case or utility function. <!-- TODO: remove -->
-
 ### Example Use Cases
 
 I use this package in collaborative situations, where individual users perform actions in order, but some of these actions may be deleted/undone/not-yet-received - causing sparsity.
@@ -134,8 +132,8 @@ console.log(previous.length); // Prints 2 (last present index + 1) - not necessa
 
 The serialized form, `SerializedSparseArray<T>`, uses run-length encoded deletions. Specifically, it is an array that alternates between:
 
-- arrays of present values (even indices), and
-- numbers (odd indices), representing that number of deleted values.
+- - arrays of present values, and
+- - numbers, representing that number of deleted values.
 
 For example:
 

--- a/benchmark_results.txt
+++ b/benchmark_results.txt
@@ -1,30 +1,30 @@
-SparseArray         append              56.2 +- 6.8 ms
-SparseString        append              101.1 +- 5.3 ms
-SparseIndices       append              50.0 +- 4.4 ms
-PlainArray          append              184.1 +- 1.0 ms
-PlainArray2         append              49.1 +- 4.0 ms
+SparseArray         append              59.4 +- 1.6 ms
+SparseString        append              101.6 +- 7.1 ms
+SparseIndices       append              53.0 +- 1.2 ms
+PlainArray          append              185.9 +- 5.5 ms
+PlainArray2         append              49.1 +- 6.6 ms
 
-SparseArray         backspace           177.3 +- 2.2 ms
-SparseString        backspace           166.1 +- 6.8 ms
-SparseIndices       backspace           138.2 +- 7.8 ms
-PlainArray          backspace           164.7 +- 9.0 ms
-PlainArray2         backspace           135.3 +- 8.9 ms
+SparseArray         backspace           140.5 +- 6.5 ms
+SparseString        backspace           171.1 +- 9.0 ms
+SparseIndices       backspace           142.5 +- 1.0 ms
+PlainArray          backspace           171.0 +- 4.5 ms
+PlainArray2         backspace           140.9 +- 1.2 ms
 
-SparseArray         randomDeletes       461.2 +- 4.1 ms
-SparseString        randomDeletes       458.7 +- 3.4 ms
-SparseIndices       randomDeletes       297.2 +- 8.3 ms
-PlainArray          randomDeletes       311.1 +- 2.6 ms
-PlainArray2         randomDeletes       280.6 +- 3.8 ms
+SparseArray         randomDeletes       398.2 +- 4.8 ms
+SparseString        randomDeletes       433.0 +- 7.8 ms
+SparseIndices       randomDeletes       278.7 +- 1.3 ms
+PlainArray          randomDeletes       310.9 +- 6.3 ms
+PlainArray2         randomDeletes       280.6 +- 7.2 ms
 
-SparseArray         frontAndBack        173.0 +- 5.3 ms
-SparseString        frontAndBack        195.4 +- 7.0 ms
-SparseIndices       frontAndBack        148.1 +- 4.5 ms
-PlainArray          frontAndBack        153.4 +- 8.0 ms
-PlainArray2         frontAndBack        87.7 +- 5.9 ms
+SparseArray         frontAndBack        159.2 +- 1.5 ms
+SparseString        frontAndBack        190.5 +- 7.8 ms
+SparseIndices       frontAndBack        144.8 +- 4.6 ms
+PlainArray          frontAndBack        155.9 +- 6.2 ms
+PlainArray2         frontAndBack        88.9 +- 1.2 ms
 
-SparseArray         textTrace           76.8 +- 7.7 ms
-SparseString        textTrace           76.2 +- 7.1 ms
-SparseIndices       textTrace           66.2 +- 1.3 ms
-PlainArray          textTrace           77.2 +- 1.7 ms
-PlainArray2         textTrace           52.7 +- 1.3 ms
+SparseArray         textTrace           72.0 +- 8.8 ms
+SparseString        textTrace           79.6 +- 8.2 ms
+SparseIndices       textTrace           60.4 +- 9.1 ms
+PlainArray          textTrace           74.6 +- 8.9 ms
+PlainArray2         textTrace           49.7 +- 5.7 ms
 

--- a/benchmark_results.txt
+++ b/benchmark_results.txt
@@ -1,30 +1,30 @@
-SparseArray         append              56.2 +- 6.8 ms
-SparseString        append              101.1 +- 5.3 ms
-SparseIndices       append              50.0 +- 4.4 ms
-PlainArray          append              184.1 +- 1.0 ms
-PlainArray2         append              49.1 +- 4.0 ms
+SparseArray         append              58.9 +- 1.7 ms
+SparseString        append              104.5 +- 2.4 ms
+SparseIndices       append              52.8 +- 3.0 ms
+PlainArray          append              182.9 +- 9.8 ms
+PlainArray2         append              50.0 +- 6.1 ms
 
-SparseArray         backspace           177.3 +- 2.2 ms
-SparseString        backspace           166.1 +- 6.8 ms
-SparseIndices       backspace           138.2 +- 7.8 ms
-PlainArray          backspace           164.7 +- 9.0 ms
-PlainArray2         backspace           135.3 +- 8.9 ms
+SparseArray         backspace           177.2 +- 6.1 ms
+SparseString        backspace           166.1 +- 10.0 ms
+SparseIndices       backspace           141.4 +- 7.2 ms
+PlainArray          backspace           171.6 +- 2.7 ms
+PlainArray2         backspace           140.8 +- 6.8 ms
 
-SparseArray         randomDeletes       461.2 +- 4.1 ms
-SparseString        randomDeletes       458.7 +- 3.4 ms
-SparseIndices       randomDeletes       297.2 +- 8.3 ms
-PlainArray          randomDeletes       311.1 +- 2.6 ms
-PlainArray2         randomDeletes       280.6 +- 3.8 ms
+SparseArray         randomDeletes       450.4 +- 7.6 ms
+SparseString        randomDeletes       440.3 +- 6.3 ms
+SparseIndices       randomDeletes       277.5 +- 0.9 ms
+PlainArray          randomDeletes       321.4 +- 4.5 ms
+PlainArray2         randomDeletes       281.6 +- 2.0 ms
 
-SparseArray         frontAndBack        173.0 +- 5.3 ms
-SparseString        frontAndBack        195.4 +- 7.0 ms
-SparseIndices       frontAndBack        148.1 +- 4.5 ms
-PlainArray          frontAndBack        153.4 +- 8.0 ms
-PlainArray2         frontAndBack        87.7 +- 5.9 ms
+SparseArray         frontAndBack        169.6 +- 0.9 ms
+SparseString        frontAndBack        191.4 +- 6.8 ms
+SparseIndices       frontAndBack        143.9 +- 4.1 ms
+PlainArray          frontAndBack        154.7 +- 6.9 ms
+PlainArray2         frontAndBack        90.6 +- 6.1 ms
 
-SparseArray         textTrace           76.8 +- 7.7 ms
-SparseString        textTrace           76.2 +- 7.1 ms
-SparseIndices       textTrace           66.2 +- 1.3 ms
-PlainArray          textTrace           77.2 +- 1.7 ms
-PlainArray2         textTrace           52.7 +- 1.3 ms
+SparseArray         textTrace           81.2 +- 9.0 ms
+SparseString        textTrace           80.9 +- 5.8 ms
+SparseIndices       textTrace           63.3 +- 7.5 ms
+PlainArray          textTrace           76.7 +- 10.5 ms
+PlainArray2         textTrace           51.8 +- 6.9 ms
 

--- a/benchmark_results.txt
+++ b/benchmark_results.txt
@@ -1,30 +1,30 @@
-SparseArray         append              59.4 +- 1.6 ms
-SparseString        append              101.6 +- 7.1 ms
-SparseIndices       append              53.0 +- 1.2 ms
-PlainArray          append              185.9 +- 5.5 ms
-PlainArray2         append              49.1 +- 6.6 ms
+SparseArray         append              56.2 +- 6.8 ms
+SparseString        append              101.1 +- 5.3 ms
+SparseIndices       append              50.0 +- 4.4 ms
+PlainArray          append              184.1 +- 1.0 ms
+PlainArray2         append              49.1 +- 4.0 ms
 
-SparseArray         backspace           140.5 +- 6.5 ms
-SparseString        backspace           171.1 +- 9.0 ms
-SparseIndices       backspace           142.5 +- 1.0 ms
-PlainArray          backspace           171.0 +- 4.5 ms
-PlainArray2         backspace           140.9 +- 1.2 ms
+SparseArray         backspace           177.3 +- 2.2 ms
+SparseString        backspace           166.1 +- 6.8 ms
+SparseIndices       backspace           138.2 +- 7.8 ms
+PlainArray          backspace           164.7 +- 9.0 ms
+PlainArray2         backspace           135.3 +- 8.9 ms
 
-SparseArray         randomDeletes       398.2 +- 4.8 ms
-SparseString        randomDeletes       433.0 +- 7.8 ms
-SparseIndices       randomDeletes       278.7 +- 1.3 ms
-PlainArray          randomDeletes       310.9 +- 6.3 ms
-PlainArray2         randomDeletes       280.6 +- 7.2 ms
+SparseArray         randomDeletes       461.2 +- 4.1 ms
+SparseString        randomDeletes       458.7 +- 3.4 ms
+SparseIndices       randomDeletes       297.2 +- 8.3 ms
+PlainArray          randomDeletes       311.1 +- 2.6 ms
+PlainArray2         randomDeletes       280.6 +- 3.8 ms
 
-SparseArray         frontAndBack        159.2 +- 1.5 ms
-SparseString        frontAndBack        190.5 +- 7.8 ms
-SparseIndices       frontAndBack        144.8 +- 4.6 ms
-PlainArray          frontAndBack        155.9 +- 6.2 ms
-PlainArray2         frontAndBack        88.9 +- 1.2 ms
+SparseArray         frontAndBack        173.0 +- 5.3 ms
+SparseString        frontAndBack        195.4 +- 7.0 ms
+SparseIndices       frontAndBack        148.1 +- 4.5 ms
+PlainArray          frontAndBack        153.4 +- 8.0 ms
+PlainArray2         frontAndBack        87.7 +- 5.9 ms
 
-SparseArray         textTrace           72.0 +- 8.8 ms
-SparseString        textTrace           79.6 +- 8.2 ms
-SparseIndices       textTrace           60.4 +- 9.1 ms
-PlainArray          textTrace           74.6 +- 8.9 ms
-PlainArray2         textTrace           49.7 +- 5.7 ms
+SparseArray         textTrace           76.8 +- 7.7 ms
+SparseString        textTrace           76.2 +- 7.1 ms
+SparseIndices       textTrace           66.2 +- 1.3 ms
+PlainArray          textTrace           77.2 +- 1.7 ms
+PlainArray2         textTrace           52.7 +- 1.3 ms
 

--- a/benchmark_results.txt
+++ b/benchmark_results.txt
@@ -1,30 +1,30 @@
-SparseArray         append              92.4 +- 7.4 ms
-SparseString        append              144.0 +- 5.3 ms
-SparseIndices       append              77.9 +- 3.1 ms
-PlainArray          append              185.6 +- 3.3 ms
-PlainArray2         append              51.1 +- 2.6 ms
+SparseArray         append              56.2 +- 6.8 ms
+SparseString        append              101.1 +- 5.3 ms
+SparseIndices       append              50.0 +- 4.4 ms
+PlainArray          append              184.1 +- 1.0 ms
+PlainArray2         append              49.1 +- 4.0 ms
 
-SparseArray         backspace           187.7 +- 2.5 ms
-SparseString        backspace           166.8 +- 2.0 ms
-SparseIndices       backspace           143.4 +- 4.2 ms
-PlainArray          backspace           170.4 +- 3.1 ms
-PlainArray2         backspace           137.8 +- 4.3 ms
+SparseArray         backspace           177.3 +- 2.2 ms
+SparseString        backspace           166.1 +- 6.8 ms
+SparseIndices       backspace           138.2 +- 7.8 ms
+PlainArray          backspace           164.7 +- 9.0 ms
+PlainArray2         backspace           135.3 +- 8.9 ms
 
-SparseArray         randomDeletes       442.8 +- 7.9 ms
-SparseString        randomDeletes       436.0 +- 3.7 ms
-SparseIndices       randomDeletes       272.8 +- 7.2 ms
-PlainArray          randomDeletes       311.6 +- 1.3 ms
-PlainArray2         randomDeletes       279.6 +- 9.4 ms
+SparseArray         randomDeletes       461.2 +- 4.1 ms
+SparseString        randomDeletes       458.7 +- 3.4 ms
+SparseIndices       randomDeletes       297.2 +- 8.3 ms
+PlainArray          randomDeletes       311.1 +- 2.6 ms
+PlainArray2         randomDeletes       280.6 +- 3.8 ms
 
-SparseArray         frontAndBack        161.7 +- 8.2 ms
-SparseString        frontAndBack        197.5 +- 1.3 ms
-SparseIndices       frontAndBack        148.2 +- 7.1 ms
-PlainArray          frontAndBack        155.7 +- 5.9 ms
-PlainArray2         frontAndBack        91.6 +- 1.6 ms
+SparseArray         frontAndBack        173.0 +- 5.3 ms
+SparseString        frontAndBack        195.4 +- 7.0 ms
+SparseIndices       frontAndBack        148.1 +- 4.5 ms
+PlainArray          frontAndBack        153.4 +- 8.0 ms
+PlainArray2         frontAndBack        87.7 +- 5.9 ms
 
-SparseArray         textTrace           77.5 +- 3.8 ms
-SparseString        textTrace           79.2 +- 5.4 ms
-SparseIndices       textTrace           63.1 +- 7.7 ms
-PlainArray          textTrace           72.6 +- 7.3 ms
-PlainArray2         textTrace           51.2 +- 7.2 ms
+SparseArray         textTrace           76.8 +- 7.7 ms
+SparseString        textTrace           76.2 +- 7.1 ms
+SparseIndices       textTrace           66.2 +- 1.3 ms
+PlainArray          textTrace           77.2 +- 1.7 ms
+PlainArray2         textTrace           52.7 +- 1.3 ms
 

--- a/benchmark_results.txt
+++ b/benchmark_results.txt
@@ -1,30 +1,30 @@
-SparseArray         append              55.5 +- 12.3 ms
-SparseString        append              121.7 +- 7.7 ms
-SparseIndices       append              61.8 +- 12.5 ms
-PlainArray          append              205.2 +- 5.7 ms
-PlainArray2         append              49.8 +- 7.0 ms
+SparseArray         append              92.4 +- 7.4 ms
+SparseString        append              144.0 +- 5.3 ms
+SparseIndices       append              77.9 +- 3.1 ms
+PlainArray          append              185.6 +- 3.3 ms
+PlainArray2         append              51.1 +- 2.6 ms
 
-SparseArray         backspace           116.7 +- 3.7 ms
-SparseString        backspace           100.6 +- 8.4 ms
-SparseIndices       backspace           73.6 +- 5.6 ms
-PlainArray          backspace           183.9 +- 6.1 ms
-PlainArray2         backspace           157.3 +- 7.6 ms
+SparseArray         backspace           187.7 +- 2.5 ms
+SparseString        backspace           166.8 +- 2.0 ms
+SparseIndices       backspace           143.4 +- 4.2 ms
+PlainArray          backspace           170.4 +- 3.1 ms
+PlainArray2         backspace           137.8 +- 4.3 ms
 
-SparseArray         randomDeletes       411.9 +- 7.7 ms
-SparseString        randomDeletes       442.3 +- 8.0 ms
-SparseIndices       randomDeletes       241.9 +- 6.9 ms
-PlainArray          randomDeletes       317.7 +- 2.8 ms
-PlainArray2         randomDeletes       282.8 +- 1.0 ms
+SparseArray         randomDeletes       442.8 +- 7.9 ms
+SparseString        randomDeletes       436.0 +- 3.7 ms
+SparseIndices       randomDeletes       272.8 +- 7.2 ms
+PlainArray          randomDeletes       311.6 +- 1.3 ms
+PlainArray2         randomDeletes       279.6 +- 9.4 ms
 
-SparseArray         frontAndBack        109.7 +- 7.0 ms
-SparseString        frontAndBack        123.4 +- 10.0 ms
-SparseIndices       frontAndBack        83.3 +- 1.3 ms
-PlainArray          frontAndBack        170.0 +- 5.2 ms
-PlainArray2         frontAndBack        98.8 +- 5.9 ms
+SparseArray         frontAndBack        161.7 +- 8.2 ms
+SparseString        frontAndBack        197.5 +- 1.3 ms
+SparseIndices       frontAndBack        148.2 +- 7.1 ms
+PlainArray          frontAndBack        155.7 +- 5.9 ms
+PlainArray2         frontAndBack        91.6 +- 1.6 ms
 
-SparseArray         textTrace           61.9 +- 8.3 ms
-SparseString        textTrace           67.4 +- 3.4 ms
-SparseIndices       textTrace           49.5 +- 7.5 ms
-PlainArray          textTrace           86.6 +- 4.3 ms
-PlainArray2         textTrace           54.3 +- 8.1 ms
+SparseArray         textTrace           77.5 +- 3.8 ms
+SparseString        textTrace           79.2 +- 5.4 ms
+SparseIndices       textTrace           63.1 +- 7.7 ms
+PlainArray          textTrace           72.6 +- 7.3 ms
+PlainArray2         textTrace           51.2 +- 7.2 ms
 

--- a/benchmarks/impls/plain_array.ts
+++ b/benchmarks/impls/plain_array.ts
@@ -6,7 +6,7 @@ export const PlainArrayImpl: Implementation = {
     return [];
   },
   isEmpty(arr: object) {
-    // Note: misses if arr is all holes.
+    // Note: misses if arr is all empty slots.
     const arr2 = arr as unknown[];
     return arr2.length === 0;
   },
@@ -37,7 +37,7 @@ export const PlainArray2Impl: Implementation = {
     return [];
   },
   isEmpty(arr: object) {
-    // Note: misses if arr is all holes.
+    // Note: misses if arr is all empty slots.
     const arr2 = arr as unknown[];
     return arr2.length === 0;
   },

--- a/src/sparse_array.ts
+++ b/src/sparse_array.ts
@@ -207,7 +207,7 @@ class ArrayNode<T> extends PresentNode<T[]> {
     return true;
   }
 
-  cloneItem(): T[] {
-    return this.item.slice();
+  sliceItem(start?: number, end?: number): T[] {
+    return this.item.slice(start, end);
   }
 }

--- a/src/sparse_array.ts
+++ b/src/sparse_array.ts
@@ -9,15 +9,14 @@ import {
  * Serialized form of a `SparseArray<T>`.
  *
  * The serialized form uses a compact JSON representation with run-length encoded deletions. It alternates between:
- * - arrays of present values (even indices), and
- * - numbers (odd indices), representing that number of deleted values.
+ * - arrays of present values, and
+ * - numbers, representing that number of deleted values.
  *
  * For example, the sparse array `["foo", "bar", , , , "X", "yy"]` serializes to
  * `[["foo", "bar"], 3, ["X", "yy"]]`.
  *
- * Trivial entries (empty arrays, 0s, & trailing deletions) are always omitted,
- * except that the 0th entry may be an empty array.
- * For example, the sparse array `[, , "biz", "baz"]` serializes to `[[], 2, ["biz", "baz"]]`.
+ * Trivial entries (empty arrays, 0s, & trailing deletions) are always omitted.
+ * For example, the sparse array `[, , "biz", "baz"]` serializes to `[2, ["biz", "baz"]]`.
  */
 export type SerializedSparseArray<T> = (T[] | number)[];
 

--- a/src/sparse_array.ts
+++ b/src/sparse_array.ts
@@ -166,9 +166,8 @@ class ArrayNode<T> extends PresentNode<T[]> {
   }
 
   splitContent(index: number): PresentNode<T[]> {
-    const after = new ArrayNode(this.item.slice(index));
-    this.item.length = index;
-    return after;
+    const afterContent = this.item.splice(index);
+    return new ArrayNode(afterContent);
   }
 
   tryMergeContent(other: PresentNode<T[]>): boolean {

--- a/src/sparse_array.ts
+++ b/src/sparse_array.ts
@@ -58,7 +58,7 @@ export interface ArraySlicer<T> {
  * in principle, due to internal searches (similar to balanced-tree
  * collections).
  *
- * To construct a SparseArray, use the static `new`, `fromEntries`, or `deserialize` methods.
+ * To construct a SparseArray, use the static `new` or `deserialize` methods.
  *
  * @see SparseString For a memory-optimized array of chars.
  * @see SparseIndices To track a sparse array's present indices independent of its values.
@@ -92,43 +92,6 @@ export class SparseArray<T> extends SparseItems<T[]> {
     );
   }
 
-  // TODO. Do we even need this method?
-  // If re-added, uncomment tests.
-  // /**
-  //  * Returns a new SparseArray with the given entries.
-  //  *
-  //  * The entries must be in order by index.
-  //  *
-  //  * @see SparseArray.entries
-  //  */
-  // static fromEntries<T>(
-  //   entries: Iterable<[index: number, value: T]>
-  // ): SparseArray<T> {
-  //   const startHolder: {next: Node<T[]> | null} = {next: null};
-  //   let current: Node<I> | null = null;
-  //   let curLength = 0;
-
-  //   for (const [index, value] of entries) {
-  //     if (index < curLength) {
-  //       throw new Error(
-  //         `Out-of-order index in entries: ${index}, previous was ${
-  //           curLength - 1
-  //         }`
-  //       );
-  //     }
-
-  //     if (index === curLength && pairs.length !== 0) {
-  //       pairs[pairs.length - 1].item.push(value);
-  //     } else {
-  //       checkIndex(index);
-  //       pairs.push({ index, item: [value] });
-  //     }
-  //     curLength = index + 1;
-  //   }
-
-  //   return new SparseArray(pairs);
-  // }
-
   /**
    * Returns a compact JSON representation of our state.
    *
@@ -156,8 +119,6 @@ export class SparseArray<T> extends SparseItems<T[]> {
 
   /**
    * Iterates over the present [index, value] pairs, in order.
-   *
-   * @see SparseArray.fromEntries
    */
   *entries(): IterableIterator<[index: number, value: T]> {
     for (const [index, item] of this.items()) {

--- a/src/sparse_array.ts
+++ b/src/sparse_array.ts
@@ -4,7 +4,6 @@ import {
   SparseItems,
   deserializeItems,
 } from "./sparse_items";
-import { checkIndex } from "./util";
 
 /**
  * Serialized form of a `SparseArray<T>`.

--- a/src/sparse_array.ts
+++ b/src/sparse_array.ts
@@ -166,8 +166,9 @@ class ArrayNode<T> extends PresentNode<T[]> {
   }
 
   splitContent(index: number): PresentNode<T[]> {
-    const afterContent = this.item.splice(index);
-    return new ArrayNode(afterContent);
+    const after = new ArrayNode(this.item.slice(index));
+    this.item.length = index;
+    return after;
   }
 
   tryMergeContent(other: PresentNode<T[]>): boolean {

--- a/src/sparse_array.ts
+++ b/src/sparse_array.ts
@@ -93,39 +93,42 @@ export class SparseArray<T> extends SparseItems<T[]> {
     );
   }
 
-  /**
-   * Returns a new SparseArray with the given entries.
-   *
-   * The entries must be in order by index.
-   *
-   * @see SparseArray.entries
-   */
-  static fromEntries<T>(
-    entries: Iterable<[index: number, value: T]>
-  ): SparseArray<T> {
-    const pairs: Pair<T[]>[] = [];
-    let curLength = 0;
+  // TODO. Do we even need this method?
+  // If re-added, uncomment tests.
+  // /**
+  //  * Returns a new SparseArray with the given entries.
+  //  *
+  //  * The entries must be in order by index.
+  //  *
+  //  * @see SparseArray.entries
+  //  */
+  // static fromEntries<T>(
+  //   entries: Iterable<[index: number, value: T]>
+  // ): SparseArray<T> {
+  //   const startHolder: {next: Node<T[]> | null} = {next: null};
+  //   let current: Node<I> | null = null;
+  //   let curLength = 0;
 
-    for (const [index, value] of entries) {
-      if (index < curLength) {
-        throw new Error(
-          `Out-of-order index in entries: ${index}, previous was ${
-            curLength - 1
-          }`
-        );
-      }
+  //   for (const [index, value] of entries) {
+  //     if (index < curLength) {
+  //       throw new Error(
+  //         `Out-of-order index in entries: ${index}, previous was ${
+  //           curLength - 1
+  //         }`
+  //       );
+  //     }
 
-      if (index === curLength && pairs.length !== 0) {
-        pairs[pairs.length - 1].item.push(value);
-      } else {
-        checkIndex(index);
-        pairs.push({ index, item: [value] });
-      }
-      curLength = index + 1;
-    }
+  //     if (index === curLength && pairs.length !== 0) {
+  //       pairs[pairs.length - 1].item.push(value);
+  //     } else {
+  //       checkIndex(index);
+  //       pairs.push({ index, item: [value] });
+  //     }
+  //     curLength = index + 1;
+  //   }
 
-    return new SparseArray(pairs);
-  }
+  //   return new SparseArray(pairs);
+  // }
 
   /**
    * Returns a compact JSON representation of our state.

--- a/src/sparse_array.ts
+++ b/src/sparse_array.ts
@@ -87,7 +87,7 @@ export class SparseArray<T> extends SparseItems<T[]> {
         if (!Array.isArray(allegedItem)) {
           throw new Error(`Invalid item in serialized state: ${allegedItem}`);
         }
-        return new ArrayNode<T>(allegedItem as T[]);
+        return new ArrayNode<T>((allegedItem as T[]).slice());
       })
     );
   }

--- a/src/sparse_indices.ts
+++ b/src/sparse_indices.ts
@@ -102,40 +102,6 @@ export class SparseIndices extends SparseItems<number> {
     return new SparseIndices(startHolder.next);
   }
 
-  // TODO. Do we even need this method?
-  // If re-added, uncomment tests.
-  // /**
-  //  * Returns a new SparseIndices with the given keys (indices).
-  //  *
-  //  * The keys must be in order by index.
-  //  *
-  //  * @see SparseIndices.keys
-  //  */
-  // static fromKeys(keys: Iterable<number>): SparseIndices {
-  //   const pairs: Pair<number>[] = [];
-  //   let curLength = 0;
-
-  //   for (const index of keys) {
-  //     if (index < curLength) {
-  //       throw new Error(
-  //         `Out-of-order index in entries: ${index}, previous was ${
-  //           curLength - 1
-  //         }`
-  //       );
-  //     }
-
-  //     if (index === curLength && pairs.length !== 0) {
-  //       pairs[pairs.length - 1].item++;
-  //     } else {
-  //       checkIndex(index);
-  //       pairs.push({ index, item: 1 });
-  //     }
-  //     curLength = index + 1;
-  //   }
-
-  //   return new SparseIndices(pairs);
-  // }
-
   /**
    * Returns a compact JSON representation of our state.
    *

--- a/src/sparse_indices.ts
+++ b/src/sparse_indices.ts
@@ -137,7 +137,7 @@ export class SparseIndices extends SparseItems<number> {
   /**
    * Sets values to be present, starting at index.
    *
-   * That is, sets all values in the range [index, index + values.length) to be present.
+   * That is, sets all values in the range [index, index + count) to be present.
    *
    * @returns A SparseIndices describing the previous values' presence.
    * Index 0 in the returned array corresponds to `index` in this array.

--- a/src/sparse_indices.ts
+++ b/src/sparse_indices.ts
@@ -5,10 +5,6 @@ import {
   DeletedNode,
   append,
 } from "./sparse_items";
-
-// TODO: needs to use different serialize/deserialize.
-// TODO: update serialized form descriptions on other classes (no longer alternating or strict start).
-
 /**
  * Serialized form of a SparseIndices.
  *

--- a/src/sparse_indices.ts
+++ b/src/sparse_indices.ts
@@ -47,7 +47,7 @@ export interface IndicesSlicer {
  *
  * SparseIndices is functionally identical to a SparseArray, except that
  * it only stores which indices are present, not their associated values.
- * This typically uses 4x less memory and results in smaller JSON.
+ * This typically uses much less memory (4x in our benchmarks) and results in much smaller JSON.
  */
 export class SparseIndices extends SparseItems<number> {
   // So list-positions can refer to unbound versions, we avoid using

--- a/src/sparse_indices.ts
+++ b/src/sparse_indices.ts
@@ -1,6 +1,9 @@
 import { Itemer, Pair, SparseItems, deserializeItems } from "./sparse_items";
 import { checkIndex } from "./util";
 
+// TODO: needs to use different serialize/deserialize.
+// TODO: update serialized form descriptions on other classes (no longer alternating or strict start).
+
 /**
  * Serialized form of a SparseIndices.
  *

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -442,7 +442,9 @@ export abstract class SparseItems<I> {
     };
 
     if (beforeLeft.next === null) {
-      beforeLeft.next = new DeletedNode(node.length);
+      // Shortcut: Directly append the node.
+      append(beforeLeft, node);
+      return this.construct(null);
     }
     const afterLeft = beforeLeft.next;
 
@@ -505,7 +507,10 @@ function locate<I>(
  * Connects before to after in the list, merging if possible.
  * Returns the final node, whose next pointer is *not* updated.
  */
-export function append<I>(before: { next: Node<I> | null }, after: Node<I>): Node<I> {
+export function append<I>(
+  before: { next: Node<I> | null },
+  after: Node<I>
+): Node<I> {
   if (before instanceof PresentNode && after instanceof PresentNode) {
     const success = before.tryMergeContent(after);
     if (success) return before;

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -1,7 +1,5 @@
 import { checkIndex } from "./util";
 
-// TODO: opt for simple overwrite (like prev Itemer.update method)? Check benchmarks.
-
 export abstract class PresentNode<I> {
   next: Node<I> | null = null;
   abstract item: I;
@@ -413,7 +411,6 @@ export abstract class SparseItems<I> {
   }
 
   // TODO: careful about aliasing
-  // TODO: check for no-deleted-ends in tests, incl after loading
   private overwrite(index: number, node: Node<I>): this {
     checkIndex(index);
 

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -349,10 +349,9 @@ export abstract class SparseItems<I> {
   /**
    * Returns a compact JSON-serializable representation of our state.
    *
-   * TODO
-   * The return value uses a run-length encoding: it alternates between
-   * - present items (even indices), and
-   * - numbers (odd indices), representing that number of deleted values.
+   * It consists of items (indicating present values) and numbers
+   * (indicating deletions). It is normalized so that entries are
+   * always nontrivial and cannot be merged with their neighbors.
    */
   serialize(): (I | number)[] {
     if (this.next === null) return [];
@@ -410,7 +409,6 @@ export abstract class SparseItems<I> {
     return this.overwrite(index, this.newNode(item));
   }
 
-  // TODO: careful about aliasing
   private overwrite(index: number, node: Node<I>): this {
     checkIndex(index);
 
@@ -541,16 +539,12 @@ function split<I>(node: Node<I>, offset: number): void {
   }
 }
 
-// TODO: test that untrimmed cases are not externally visible (length, isEmpty, serialized).
-
 /**
- * Templated implementation of deserialization
+ * Templated implementation of deserialization.
  *
  * Each subclass implements a static `deserialize` method as
- * `return new <class>(deserializeItems(serialized, <class's itemer>))`.
- *
- * TODO: document number restriction. Might need a separate method for SparseIndices,
- * along with serialize().
+ * `return new <class>(deserializeItems(serialized, <class's itemer>))`,
+ * except for SparseIndices which uses a different serialized form.
  *
  * @param newNode Unlike internal newNode method, must validate and shallow-clone item.
  * If invalid, throw error. (It's user input.)

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -505,7 +505,7 @@ function locate<I>(
  * Connects before to after in the list, merging if possible.
  * Returns the final node, whose next pointer is *not* updated.
  */
-function append<I>(before: { next: Node<I> | null }, after: Node<I>): Node<I> {
+export function append<I>(before: { next: Node<I> | null }, after: Node<I>): Node<I> {
   if (before instanceof PresentNode && after instanceof PresentNode) {
     const success = before.tryMergeContent(after);
     if (success) return before;

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -530,8 +530,9 @@ export function deserializeItems<I>(
     }
     previous = append(previous, node);
   }
+  // TODO: if the last node is deleted, trim it.
 
-  return previous.next;
+  return startHolder.next;
 }
 
 /**

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -436,6 +436,13 @@ export abstract class SparseItems<I> {
     if (this.next === null) {
       this.next = new DeletedNode(index + node.length);
     }
+
+    if (this.next.next === null && this.next.length === index) {
+      // Common case opt: Appending to non-sparse array (single node).
+      if (node instanceof PresentNode) append(this.next, node);
+      return this.construct(null);
+    }
+
     // Cast needed due to https://github.com/microsoft/TypeScript/issues/9974
     const beforeLeft = (index === 0 ? this : createSplit(this.next, index)) as {
       next: Node<I> | null;

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -193,7 +193,7 @@ export abstract class SparseItems<I> {
 
     let remaining = index;
     for (let current = this.next; current !== null; current = current.next) {
-      if (current.length < remaining) {
+      if (remaining < current.length) {
         if (current instanceof DeletedNode) return null;
         else return [current.item, remaining];
       }
@@ -417,6 +417,7 @@ export abstract class SparseItems<I> {
       left.next = null;
     }
 
+    // TODO: need to trim replaced (preRight might be deleted).
     const replaced = this.construct(null);
     replaced.next = replacedStart;
     return replaced;

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -32,7 +32,7 @@ export abstract class PresentNode<I> {
   abstract sliceItem(start?: number, end?: number): I;
 }
 
-class DeletedNode<I> {
+export class DeletedNode<I> {
   next: Node<I> | null = null;
   constructor(public length: number) {}
   /**

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -117,8 +117,7 @@ export abstract class SparseItems<I> {
    * All methods accept index arguments `>= this.length`, acting as if
    * the array ends with infinitely many deleted indices (empty slots).
    *
-   * Note: Unlike an ordinary `Array`, you cannot explicitly set the length
-   * to include additional deleted indices.
+   * Note: Unlike an ordinary `Array`, you cannot explicitly set the length.
    */
   get length(): number {
     if (this.next === null) return 0;
@@ -485,7 +484,7 @@ function createSplit<I>(start: Node<I>, delta: number): Node<I> {
  * Given delta > 0, returns the node containing that index and the offset within it.
  * The returned offset satisfies 0 < offset <= node.length, unless delta is outside
  * the list, in which case offset is greater and outside is true.
- * 
+ *
  * If delta is 0, returns [start, 0, false].
  */
 function locate<I>(

--- a/src/sparse_items.ts
+++ b/src/sparse_items.ts
@@ -450,9 +450,13 @@ export abstract class SparseItems<I> {
     const afterRight = beforeRight.next;
 
     beforeLeft.next = null;
-    const nodeEnd = append(beforeLeft, node);
-    if (afterRight === null) nodeEnd.next = null;
-    else append(nodeEnd, afterRight);
+    const appendedNode = append(beforeLeft, node);
+    if (afterRight === null) appendedNode.next = null;
+    else {
+      // Append while preserving afterRight.next.
+      const appendedAfterRight = append(appendedNode, afterRight);
+      appendedAfterRight.next = afterRight.next;
+    }
 
     // Return the replaced list.
     beforeRight.next = null;

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -4,7 +4,6 @@ import {
   SparseItems,
   deserializeItems,
 } from "./sparse_items";
-import { checkIndex } from "./util";
 
 /**
  * Serialized form of a SparseString.
@@ -93,39 +92,39 @@ export class SparseString<E extends object | never = never> extends SparseItems<
     );
   }
 
-  /**
-   * Returns a new SparseString with the given entries.
-   *
-   * The entries must be in order by index.
-   *
-   * @see SparseString.entries
-   */
-  static fromEntries<E extends object | never = never>(
-    entries: Iterable<[index: number, char: string | E]>
-  ): SparseString<E> {
-    const pairs: Pair<string>[] = [];
-    let curLength = 0;
+  // /**
+  //  * Returns a new SparseString with the given entries.
+  //  *
+  //  * The entries must be in order by index.
+  //  *
+  //  * @see SparseString.entries
+  //  */
+  // static fromEntries<E extends object | never = never>(
+  //   entries: Iterable<[index: number, char: string | E]>
+  // ): SparseString<E> {
+  //   const pairs: Pair<string>[] = [];
+  //   let curLength = 0;
 
-    for (const [index, char] of entries) {
-      if (index < curLength) {
-        throw new Error(
-          `Out-of-order index in entries: ${index}, previous was ${
-            curLength - 1
-          }`
-        );
-      }
+  //   for (const [index, char] of entries) {
+  //     if (index < curLength) {
+  //       throw new Error(
+  //         `Out-of-order index in entries: ${index}, previous was ${
+  //           curLength - 1
+  //         }`
+  //       );
+  //     }
 
-      if (index === curLength && pairs.length !== 0) {
-        pairs[pairs.length - 1].item += char;
-      } else {
-        checkIndex(index);
-        pairs.push({ index, item: char });
-      }
-      curLength = index + 1;
-    }
+  //     if (index === curLength && pairs.length !== 0) {
+  //       pairs[pairs.length - 1].item += char;
+  //     } else {
+  //       checkIndex(index);
+  //       pairs.push({ index, item: char });
+  //     }
+  //     curLength = index + 1;
+  //   }
 
-    return new SparseString(pairs);
-  }
+  //   return new SparseString(pairs);
+  // }
 
   /**
    * Returns a compact JSON representation of our state.
@@ -149,7 +148,7 @@ export class SparseString<E extends object | never = never> extends SparseItems<
     else return item;
   }
 
-  newSlicer(): StringSlicer {
+  newSlicer(): StringSlicer<E> {
     return super.newSlicer();
   }
 

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -16,6 +16,7 @@ import {
  * For example, the sparse string `["a", "b", , , , "f", "g"]` serializes to `["ab", 3, "fg"]`.
  *
  * Trivial entries (empty strings, 0s, & trailing deletions) are always omitted.
+ * For example, the sparse string `[, , "x", "y"]` serializes to `[2, "xy"]`.
  */
 export type SerializedSparseString<E extends object | never = never> = (
   | string
@@ -56,8 +57,6 @@ export interface StringSlicer<E extends object | never = never> {
  *
  * @see SparseIndices To track a sparse array's present indices independent of its values.
  */
-// TODO: default to never, once we check all usages.
-// TODO: test that never does what you expect for consumers.
 export class SparseString<E extends object | never = never> extends SparseItems<
   string | E
 > {

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -9,15 +9,14 @@ import { checkIndex } from "./util";
 /**
  * Serialized form of a SparseString.
  *
- * The serialized form uses a compact JSON representation with run-length encoded deletions. It alternates between:
- * - strings of concatenated present chars (even indices), and
- * - numbers (odd indices), representing that number of deleted chars.
+ * The serialized form uses a compact JSON representation with run-length encoded deletions. It consists of:
+ * - strings of concatenated present chars,
+ * - embedded objects of type E, and
+ * - numbers, representing that number of deleted chars.
  *
  * For example, the sparse string `["a", "b", , , , "f", "g"]` serializes to `["ab", 3, "fg"]`.
  *
- * Trivial entries (empty strings, 0s, & trailing deletions) are always omitted,
- * except that the 0th entry may be an empty string.
- * For example, the sparse string `[, , "x", "y"]` serializes to `["", 2, "xy"]`.
+ * Trivial entries (empty strings, 0s, & trailing deletions) are always omitted.
  */
 export type SerializedSparseString<E extends object | never = never> = (
   | string

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -77,7 +77,7 @@ export class SparseString<E extends object | never = never> extends SparseItems<
    * @throws If the serialized form is invalid (see `SparseString.serialize`).
    */
   static deserialize<E extends object | never = never>(
-    serialized: SerializedSparseString
+    serialized: SerializedSparseString<E>
   ): SparseString<E> {
     return new SparseString<E>(
       deserializeItems<string | E>(serialized, (allegedItem) => {
@@ -169,6 +169,17 @@ export class SparseString<E extends object | never = never> extends SparseItems<
   }
 
   /**
+   * Iterates over the present items, in order.
+   *
+   * Each item [index, values] indicates either a run of present chars or a single embed,
+   * starting at index and ending at either a deleted value or a value of the opposite type
+   * (char vs embed).
+   */
+  items(): IterableIterator<[index: number, values: string | E]> {
+    return super.items();
+  }
+
+  /**
    * Sets chars starting at index.
    *
    * That is, sets all values in the range [index, index + chars.length) to the
@@ -224,6 +235,9 @@ class StringNode extends PresentNode<string> {
 class EmbedNode<E extends object | never> extends PresentNode<E> {
   constructor(public item: E) {
     super();
+    if (!(typeof item === "object" && item !== null)) {
+      throw new Error(`Embeds must be objects; received ${item}`);
+    }
   }
 
   get length(): number {

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -61,7 +61,7 @@ export interface StringSlicer<E extends object | never = never> {
  *
  * The sparse string may also contain embedded objects of type `E`.
  * Each embed takes the place of a single character. You can use embeds to represent
- * non-text content, like images and videos, that may appear inside a text document.
+ * non-text content, like images and videos, that may appear inline in a text document.
  * If you do not specify the generic type `E`, it defaults to `never`, i.e., no embeds are allowed.
  *
  * @see SparseIndices To track a sparse array's present indices independent of its values.
@@ -85,8 +85,7 @@ export class SparseString<E extends object | never = never> extends SparseItems<
    * from `SparseString.serialize`.
    *
    * @throws If the serialized form is invalid (see `SparseString.serialize`).
-   * Note that we do **not** check whether it contains embeds that fail to
-   * match type `E`.
+   * Note that we do **not** check whether the embeds match type `E`.
    */
   static deserialize<E extends object | never = never>(
     serialized: SerializedSparseString<E>

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -83,7 +83,8 @@ export class SparseString<E extends object | never = never> extends SparseItems<
       deserializeItems<string | E>(serialized, (allegedItem) => {
         if (typeof allegedItem === "string") {
           return new StringNode(allegedItem);
-        } else if (typeof allegedItem === "object") {
+        } else if (typeof allegedItem === "object" && allegedItem !== null) {
+          // We exclude null as it is not assignable to TypeScript's `object` type.
           return new EmbedNode(allegedItem as E);
         } else {
           throw new Error(`Invalid item in serialized state: ${allegedItem}`);

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -216,8 +216,8 @@ class StringNode extends PresentNode<string> {
     return false;
   }
 
-  cloneItem(): string {
-    return this.item;
+  sliceItem(start?: number, end?: number): string {
+    return this.item.slice(start, end);
   }
 }
 
@@ -238,7 +238,7 @@ class EmbedNode<E extends object | never> extends PresentNode<E> {
     return false;
   }
 
-  cloneItem(): E {
+  sliceItem(): E {
     // We don't deep-clone values, only their wrapper items.
     return this.item;
   }

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -93,40 +93,6 @@ export class SparseString<E extends object | never = never> extends SparseItems<
     );
   }
 
-  // /**
-  //  * Returns a new SparseString with the given entries.
-  //  *
-  //  * The entries must be in order by index.
-  //  *
-  //  * @see SparseString.entries
-  //  */
-  // static fromEntries<E extends object | never = never>(
-  //   entries: Iterable<[index: number, char: string | E]>
-  // ): SparseString<E> {
-  //   const pairs: Pair<string>[] = [];
-  //   let curLength = 0;
-
-  //   for (const [index, char] of entries) {
-  //     if (index < curLength) {
-  //       throw new Error(
-  //         `Out-of-order index in entries: ${index}, previous was ${
-  //           curLength - 1
-  //         }`
-  //       );
-  //     }
-
-  //     if (index === curLength && pairs.length !== 0) {
-  //       pairs[pairs.length - 1].item += char;
-  //     } else {
-  //       checkIndex(index);
-  //       pairs.push({ index, item: char });
-  //     }
-  //     curLength = index + 1;
-  //   }
-
-  //   return new SparseString(pairs);
-  // }
-
   /**
    * Returns a compact JSON representation of our state.
    *
@@ -155,8 +121,6 @@ export class SparseString<E extends object | never = never> extends SparseItems<
 
   /**
    * Iterates over the present [index, char] pairs, in order.
-   *
-   * @see SparseText.fromEntries
    */
   *entries(): IterableIterator<[index: number, char: string | E]> {
     for (const [index, item] of this.items()) {

--- a/src/sparse_string.ts
+++ b/src/sparse_string.ts
@@ -56,8 +56,8 @@ export interface StringSlicer<E extends object | never = never> {
  * SparseString is functionally identical to a SparseArray with single-char values,
  * but it uses strings (e.g. `"abc"`) instead of arrays (e.g. `["a", "b", "c"]`) in its internal state
  * and serialized form.
- * This typically uses 2x less memory and results in smaller JSON,
- * though with a slight cost in mutation speed.
+ * This typically uses less memory (2x in our benchmarks) and results in smaller JSON,
+  though with a slight cost in mutation speed.
  *
  * The sparse string may also contain embedded objects of type `E`.
  * Each embed takes the place of a single character. You can use embeds to represent

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,10 +1,3 @@
-export function nonNull<T>(x: T | null): T {
-  if (x === null) {
-    throw new Error("Internal error: non-null check failed");
-  }
-  return x;
-}
-
 export function checkIndex(index: number, desc = "index"): void {
   if (!Number.isSafeInteger(index) || index < 0) {
     throw new Error(`Invalid ${desc}: ${index}`);

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -212,10 +212,6 @@ class Checker {
     assert.strictEqual(nextEntry, entries.length);
     assert.strictEqual(nextEntry, keys.length);
 
-    // // Test fromEntries.
-    // const arr2 = SparseArray.fromEntries(entries);
-    // check(arr2, this.values);
-
     // Test items.
     const items = [...this.arr.items()];
     let prevEnd = -1;
@@ -606,44 +602,6 @@ describe("SparseArray", () => {
       assert.deepStrictEqual(arr.serialize(), initial);
     }
   });
-
-  // test("fromEntries errors", () => {
-  //   for (const bad of [-1, 0.5, NaN]) {
-  //     assert.throws(() => SparseArray.fromEntries([[bad, "x"]]));
-  //     assert.throws(() =>
-  //       SparseArray.fromEntries([
-  //         [0, "y"],
-  //         [bad, "x"],
-  //       ])
-  //     );
-  //   }
-
-  //   assert.throws(() =>
-  //     SparseArray.fromEntries([
-  //       [0, "x"],
-  //       [1, "y"],
-  //       [1, "z"],
-  //     ])
-  //   );
-
-  //   assert.throws(() =>
-  //     SparseArray.fromEntries([
-  //       [0, "x"],
-  //       [2, "y"],
-  //       [1, "z"],
-  //     ])
-  //   );
-
-  //   assert.doesNotThrow(() => SparseArray.fromEntries([]));
-  //   assert.doesNotThrow(() => SparseArray.fromEntries([[1, "x"]]));
-  //   assert.doesNotThrow(() =>
-  //     SparseArray.fromEntries([
-  //       [1, "x"],
-  //       [7, "y"],
-  //       [1000, "z"],
-  //     ])
-  //   );
-  // });
 
   test("deserialize errors", () => {
     for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -4,7 +4,7 @@ import seedrandom from "seedrandom";
 import { SerializedSparseArray, SparseArray } from "../src";
 import { DeletedNode, Node } from "../src/sparse_items";
 
-const DEBUG = false;
+const DEBUG = true;
 
 function getState<T>(arr: SparseArray<T>): Node<T[]>[] {
   const nodes: Node<T[]>[] = [];

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -269,12 +269,6 @@ class Checker {
         countBetween(this.values, 0, i),
         i < this.values.length && this.values[i] !== null,
       ]);
-      for (let j = i; j < this.values.length + 2; j++) {
-        assert.strictEqual(
-          this.arr.countBetween(i, j),
-          countBetween(this.values, i, j)
-        );
-      }
     }
 
     // Test newSlicer 10x with random slices.
@@ -551,17 +545,6 @@ describe("SparseArray", () => {
 
       // Each error case should throw and not change the array.
       // Indices >= length should *not* throw errors.
-
-      // countBetween
-      for (const bad of [-1, 0.5, NaN]) {
-        assert.throws(() => arr.countBetween(bad, 3));
-      }
-      for (const bad of [-1, 0.5, NaN]) {
-        assert.throws(() => arr.countBetween(0, bad));
-      }
-      assert.throws(() => arr.countBetween(1, -3));
-      assert.doesNotThrow(() => arr.countBetween(15, 18));
-      assert.deepStrictEqual(arr.serialize(), initial);
 
       // countAt
       for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -500,7 +500,6 @@ describe("SparseArray", () => {
   });
 
   test("toString", () => {
-    // Test both normalItem and pairs cases.
     for (const start of [0, 5]) {
       const arr = SparseArray.new<string>();
       arr.set(start, "a", "b", "c", "d", "sigil");
@@ -512,10 +511,9 @@ describe("SparseArray", () => {
   });
 
   test("clone", () => {
-    // Test both normalItem and pairs cases.
-    for (const start of [0, 5]) {
+    for (const start of [null, 0, 5]) {
       const arr = SparseArray.new<string>();
-      arr.set(start, "a", "b", "c", "d", "sigil");
+      if (start !== null) arr.set(start, "a", "b", "c", "d", "sigil");
       const cloned = arr.clone();
 
       const clonedSerialized = cloned.serialize();
@@ -564,7 +562,6 @@ describe("SparseArray", () => {
   });
 
   test("method errors", () => {
-    // Test both normalItem and pairs cases.
     for (const start of [0, 5]) {
       const arr = SparseArray.new<string>();
       arr.set(start, "a", "b", "c", "d", "e");

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -188,7 +188,7 @@ class Checker {
   }
 
   /**
-   * Test all _getAtCount inputs and some newSlicer walks.
+   * Test all indexOfCount inputs and some newSlicer walks.
    *
    * More expensive (O(length^2) ops), so only call occasionally,
    * in "interesting" states.
@@ -226,7 +226,7 @@ class Checker {
       prevEnd = index + values.length;
     }
 
-    // Test _getAtCount.
+    // Test indexOfCount.
     for (
       let startIndex = 0;
       startIndex < this.values.length + 2;
@@ -244,17 +244,9 @@ class Checker {
         }
         if (index >= this.values.length) {
           // count is too large - not found.
-          assert.deepStrictEqual(this.arr._getAtCount(count, startIndex), null);
           assert.strictEqual(this.arr.indexOfCount(count, startIndex), -1);
         } else {
           // Answer is index.
-          const actual = this.arr._getAtCount(count, startIndex);
-          assert.isNotNull(actual);
-          const [item, offset, actualIndex] = actual!;
-          assert.deepStrictEqual(
-            [item[offset], actualIndex],
-            [this.values[index], index]
-          );
           assert.strictEqual(this.arr.indexOfCount(count, startIndex), index);
         }
       }

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -375,6 +375,17 @@ describe("SparseArray", () => {
     }
   });
 
+  test("ops from serialize test", () => {
+    const checker = new Checker();
+    checker.set(0, "a", "b");
+    checker.delete(0, 2);
+    checker.set(5, "c", "d");
+    checker.delete(0, 10);
+    checker.set(0, "x");
+    checker.set(2, "y", "z");
+    checker.set(7, "A", "B", "C");
+  });
+
   describe("fuzz", () => {
     test("single char ops", () => {
       const checker = new Checker();
@@ -515,7 +526,7 @@ describe("SparseArray", () => {
     assert.deepStrictEqual(arr.serialize(), []);
 
     arr.set(5, "c", "d");
-    assert.deepStrictEqual(arr.serialize(), [[], 5, ["c", "d"]]);
+    assert.deepStrictEqual(arr.serialize(), [5, ["c", "d"]]);
 
     arr.delete(0, 10);
     assert.deepStrictEqual(arr.serialize(), []);

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -67,6 +67,8 @@ function check(arr: SparseArray<string>, values: (string | null)[]) {
   assert.strictEqual(arr.length, getPresentLength(state));
   assert.strictEqual(arr.length, getValuesLength(values));
 
+  assert.strictEqual(arr.isEmpty(), getValuesLength(values) === 0);
+
   // Queries should also work on indexes past the length.
   for (let i = 0; i < 10; i++) {
     assert.deepStrictEqual(arr.has(arr.length + i), false);
@@ -380,6 +382,28 @@ describe("SparseArray", () => {
     checker.set(0, "x");
     checker.set(2, "y", "z");
     checker.set(7, "A", "B", "C");
+  });
+
+  test("untrimmed", () => {
+    // Deliberately create arrays whose internal representation is untrimmed
+    // (ends with a deleted node) and check that length, isEmpty,
+    // and the serialized form are unaffected.
+    const checker = new Checker();
+
+    checker.set(0, ..."abcde");
+    checker.delete(0, 5);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], []);
+
+    checker.set(0, ..."abcde");
+    checker.delete(3, 2);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], [["a", "b", "c"]]);
+
+    checker.set(0, ..."abcde");
+    checker.delete(3, 5);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], [["a", "b", "c"]]);
   });
 
   describe("fuzz", () => {

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -3,8 +3,7 @@ import { describe, test } from "mocha";
 import seedrandom from "seedrandom";
 import { SerializedSparseArray, SparseArray } from "../src";
 import { DeletedNode, Node } from "../src/sparse_items";
-
-const DEBUG = true;
+import { DEBUG } from "./util";
 
 function getState<T>(arr: SparseArray<T>): Node<T[]>[] {
   const nodes: Node<T[]>[] = [];
@@ -37,16 +36,15 @@ function validate<T>(nodes: Node<T[]>[]): void {
       nodes[i + 1].constructor.name
     );
   }
-
-  // Last node is not deleted.
-  if (nodes.length !== 0) {
-    assert.isFalse(nodes[nodes.length - 1] instanceof DeletedNode);
-  }
 }
 
 function getPresentLength<T>(nodes: Node<T[]>[]): number {
   let length = 0;
   for (const node of nodes) length += node.length;
+  // Handle untrimmed case.
+  if (nodes.length !== 0 && nodes[nodes.length - 1] instanceof DeletedNode) {
+    length -= nodes[nodes.length - 1].length;
+  }
   return length;
 }
 

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -2,13 +2,17 @@ import { assert } from "chai";
 import { describe, test } from "mocha";
 import seedrandom from "seedrandom";
 import { SerializedSparseArray, SparseArray } from "../src";
-import { Pair } from "../src/sparse_items";
+import { DeletedNode } from "../src/sparse_items";
 
 const DEBUG = false;
 
-function getState<T>(arr: SparseArray<T>): Pair<T[]>[] {
-  // @ts-expect-error Ignore protected
-  return arr.asPairs();
+function getState<T>(arr: SparseArray<T>): unknown[] {
+  const nodes: unknown[] = [];
+  // @ts-expect-error Ignore private.
+  for (let current = arr.next; current !== null; current = current.next) {
+    nodes.push(current instanceof DeletedNode ? -current.length : current.item);
+  }
+  return nodes;
 }
 
 function validate<T>(pairs: Pair<T[]>[]): void {
@@ -73,7 +77,7 @@ function check(arr: SparseArray<string>, values: (string | null)[]) {
 function entriesAsItems<T>(
   entries: Array<[index: number, value: T]>
 ): Array<[index: number, item: T[]]> {
-  const pairs: Pair<T[]>[] = [];
+  const pairs: { index: number; item: T[] }[] = [];
   let curLength = 0;
 
   for (const [index, value] of entries) {

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -669,21 +669,20 @@ describe("SparseArray", () => {
       // @ts-expect-error
       SparseArray.deserialize([["a", "b", "c"], 7, {}, 3, ["m"]])
     );
-    assert.throws(() =>
+
+    assert.doesNotThrow(() =>
       SparseArray.deserialize([["a", "b", "c"], 7, 6, 3, ["m"]])
     );
-    assert.throws(() =>
+    assert.doesNotThrow(() =>
       SparseArray.deserialize([["a", "b", "c"], 7, ["x"], ["y"], ["m"]])
     );
-
-    assert.throws(() =>
+    assert.doesNotThrow(() =>
       SparseArray.deserialize([3, ["a", "b", "c"], 7, ["x", "y"], ["m"]])
     );
-
-    assert.throws(() =>
+    assert.doesNotThrow(() =>
       SparseArray.deserialize([["a", "b", "c"], 7, [], 3, ["m"]])
     );
-    assert.throws(() =>
+    assert.doesNotThrow(() =>
       SparseArray.deserialize([["a", "b", "c"], 0, ["x", "y"], 3, ["m"]])
     );
 

--- a/test/sparse_array.test.ts
+++ b/test/sparse_array.test.ts
@@ -208,9 +208,9 @@ class Checker {
     assert.strictEqual(nextEntry, entries.length);
     assert.strictEqual(nextEntry, keys.length);
 
-    // Test fromEntries.
-    const arr2 = SparseArray.fromEntries(entries);
-    check(arr2, this.values);
+    // // Test fromEntries.
+    // const arr2 = SparseArray.fromEntries(entries);
+    // check(arr2, this.values);
 
     // Test items.
     const items = [...this.arr.items()];
@@ -617,43 +617,43 @@ describe("SparseArray", () => {
     }
   });
 
-  test("fromEntries errors", () => {
-    for (const bad of [-1, 0.5, NaN]) {
-      assert.throws(() => SparseArray.fromEntries([[bad, "x"]]));
-      assert.throws(() =>
-        SparseArray.fromEntries([
-          [0, "y"],
-          [bad, "x"],
-        ])
-      );
-    }
+  // test("fromEntries errors", () => {
+  //   for (const bad of [-1, 0.5, NaN]) {
+  //     assert.throws(() => SparseArray.fromEntries([[bad, "x"]]));
+  //     assert.throws(() =>
+  //       SparseArray.fromEntries([
+  //         [0, "y"],
+  //         [bad, "x"],
+  //       ])
+  //     );
+  //   }
 
-    assert.throws(() =>
-      SparseArray.fromEntries([
-        [0, "x"],
-        [1, "y"],
-        [1, "z"],
-      ])
-    );
+  //   assert.throws(() =>
+  //     SparseArray.fromEntries([
+  //       [0, "x"],
+  //       [1, "y"],
+  //       [1, "z"],
+  //     ])
+  //   );
 
-    assert.throws(() =>
-      SparseArray.fromEntries([
-        [0, "x"],
-        [2, "y"],
-        [1, "z"],
-      ])
-    );
+  //   assert.throws(() =>
+  //     SparseArray.fromEntries([
+  //       [0, "x"],
+  //       [2, "y"],
+  //       [1, "z"],
+  //     ])
+  //   );
 
-    assert.doesNotThrow(() => SparseArray.fromEntries([]));
-    assert.doesNotThrow(() => SparseArray.fromEntries([[1, "x"]]));
-    assert.doesNotThrow(() =>
-      SparseArray.fromEntries([
-        [1, "x"],
-        [7, "y"],
-        [1000, "z"],
-      ])
-    );
-  });
+  //   assert.doesNotThrow(() => SparseArray.fromEntries([]));
+  //   assert.doesNotThrow(() => SparseArray.fromEntries([[1, "x"]]));
+  //   assert.doesNotThrow(() =>
+  //     SparseArray.fromEntries([
+  //       [1, "x"],
+  //       [7, "y"],
+  //       [1000, "z"],
+  //     ])
+  //   );
+  // });
 
   test("deserialize errors", () => {
     for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_indices.test.ts
+++ b/test/sparse_indices.test.ts
@@ -190,7 +190,7 @@ class Checker {
   }
 
   /**
-   * Test all _getAtCount inputs and some newSlicer walks.
+   * Test all indexOfCount inputs and some newSlicer walks.
    *
    * More expensive (O(length^2) ops), so only call occasionally,
    * in "interesting" states.
@@ -224,7 +224,7 @@ class Checker {
       prevEnd = index + values;
     }
 
-    // Test _getAtCount.
+    // Test indexOfCount.
     for (
       let startIndex = 0;
       startIndex < this.values.length + 2;
@@ -242,17 +242,9 @@ class Checker {
         }
         if (index >= this.values.length) {
           // count is too large - not found.
-          assert.deepStrictEqual(this.arr._getAtCount(count, startIndex), null);
           assert.strictEqual(this.arr.indexOfCount(count, startIndex), -1);
         } else {
           // Answer is index.
-          const actual = this.arr._getAtCount(count, startIndex);
-          assert.isNotNull(actual);
-          const [item, offset, actualIndex] = actual!;
-          assert.deepStrictEqual(
-            [true, actualIndex],
-            [this.values[index] !== null, index]
-          );
           assert.strictEqual(this.arr.indexOfCount(count, startIndex), index);
         }
       }

--- a/test/sparse_indices.test.ts
+++ b/test/sparse_indices.test.ts
@@ -2,13 +2,17 @@ import { assert } from "chai";
 import { describe, test } from "mocha";
 import seedrandom from "seedrandom";
 import { SerializedSparseIndices, SparseIndices } from "../src";
-import { Pair } from "../src/sparse_items";
+import { DeletedNode } from "../src/sparse_items";
 
 const DEBUG = false;
 
-function getState(arr: SparseIndices): Pair<number>[] {
-  // @ts-expect-error Ignore protected
-  return arr.asPairs();
+function getState(arr: SparseIndices): unknown[] {
+  const nodes: unknown[] = [];
+  // @ts-expect-error Ignore private.
+  for (let current = arr.next; current !== null; current = current.next) {
+    nodes.push(current instanceof DeletedNode ? -current.length : current.item);
+  }
+  return nodes;
 }
 
 function validate(pairs: Pair<number>[]): void {
@@ -207,9 +211,9 @@ class Checker {
     }
     assert.strictEqual(nextEntry, keys.length);
 
-    // Test fromKeys.
-    const arr2 = SparseIndices.fromKeys(keys);
-    check(arr2, this.values);
+    // // Test fromKeys.
+    // const arr2 = SparseIndices.fromKeys(keys);
+    // check(arr2, this.values);
 
     // Test items.
     const items = [...this.arr.items()];
@@ -582,20 +586,20 @@ describe("SparseIndices", () => {
     }
   });
 
-  test("fromKeys errors", () => {
-    for (const bad of [-1, 0.5, NaN]) {
-      assert.throws(() => SparseIndices.fromKeys([bad]));
-      assert.throws(() => SparseIndices.fromKeys([0, bad]));
-    }
+  // test("fromKeys errors", () => {
+  //   for (const bad of [-1, 0.5, NaN]) {
+  //     assert.throws(() => SparseIndices.fromKeys([bad]));
+  //     assert.throws(() => SparseIndices.fromKeys([0, bad]));
+  //   }
 
-    assert.throws(() => SparseIndices.fromKeys([0, 1, 1]));
+  //   assert.throws(() => SparseIndices.fromKeys([0, 1, 1]));
 
-    assert.throws(() => SparseIndices.fromKeys([0, 2, 1]));
+  //   assert.throws(() => SparseIndices.fromKeys([0, 2, 1]));
 
-    assert.doesNotThrow(() => SparseIndices.fromKeys([]));
-    assert.doesNotThrow(() => SparseIndices.fromKeys([1]));
-    assert.doesNotThrow(() => SparseIndices.fromKeys([1, 7, 1000]));
-  });
+  //   assert.doesNotThrow(() => SparseIndices.fromKeys([]));
+  //   assert.doesNotThrow(() => SparseIndices.fromKeys([1]));
+  //   assert.doesNotThrow(() => SparseIndices.fromKeys([1, 7, 1000]));
+  // });
 
   test("deserialize errors", () => {
     for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_indices.test.ts
+++ b/test/sparse_indices.test.ts
@@ -66,6 +66,8 @@ function check(arr: SparseIndices, values: (string | null)[]) {
   assert.strictEqual(arr.length, getPresentLength(state));
   assert.strictEqual(arr.length, getValuesLength(values));
 
+  assert.strictEqual(arr.isEmpty(), getValuesLength(values) === 0);
+
   // Queries should also work on indexes past the length.
   for (let i = 0; i < 10; i++) {
     assert.deepStrictEqual(arr.has(arr.length + i), false);
@@ -363,6 +365,28 @@ describe("SparseIndices", () => {
       if (i >= 20) checker.delete(i - 20, 1);
       if (i % 10 === 0) checker.testQueries(rng);
     }
+  });
+
+  test("untrimmed", () => {
+    // Deliberately create arrays whose internal representation is untrimmed
+    // (ends with a deleted node) and check that length, isEmpty,
+    // and the serialized form are unaffected.
+    const checker = new Checker();
+
+    checker.set(0, ..."abcde");
+    checker.delete(0, 5);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], []);
+
+    checker.set(0, ..."abcde");
+    checker.delete(3, 2);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], [3]);
+
+    checker.set(0, ..."abcde");
+    checker.delete(3, 5);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], [3]);
   });
 
   describe("fuzz", () => {

--- a/test/sparse_indices.test.ts
+++ b/test/sparse_indices.test.ts
@@ -3,8 +3,7 @@ import { describe, test } from "mocha";
 import seedrandom from "seedrandom";
 import { SerializedSparseIndices, SparseIndices } from "../src";
 import { DeletedNode, Node } from "../src/sparse_items";
-
-const DEBUG = false;
+import { DEBUG } from "./util";
 
 function getState(arr: SparseIndices): Node<number>[] {
   const nodes: Node<number>[] = [];
@@ -37,16 +36,15 @@ function validate(nodes: Node<string>[]): void {
       nodes[i + 1].constructor.name
     );
   }
-
-  // Last node is not deleted.
-  if (nodes.length !== 0) {
-    assert.isFalse(nodes[nodes.length - 1] instanceof DeletedNode);
-  }
 }
 
 function getPresentLength(nodes: Node<number>[]): number {
   let length = 0;
   for (const node of nodes) length += node.length;
+  // Handle untrimmed case.
+  if (nodes.length !== 0 && nodes[nodes.length - 1] instanceof DeletedNode) {
+    length -= nodes[nodes.length - 1].length;
+  }
   return length;
 }
 

--- a/test/sparse_indices.test.ts
+++ b/test/sparse_indices.test.ts
@@ -483,7 +483,6 @@ describe("SparseIndices", () => {
   });
 
   test("toString", () => {
-    // Test both normalItem and pairs cases.
     for (const start of [0, 5]) {
       const arr = SparseIndices.new();
       arr.set(start, 5);
@@ -495,10 +494,9 @@ describe("SparseIndices", () => {
   });
 
   test("clone", () => {
-    // Test both normalItem and pairs cases.
-    for (const start of [0, 5]) {
+    for (const start of [null, 0, 5]) {
       const arr = SparseIndices.new();
-      arr.set(start, 5);
+      if (start !== null) arr.set(start, 5);
       const cloned = arr.clone();
 
       const clonedSerialized = cloned.serialize();
@@ -541,7 +539,6 @@ describe("SparseIndices", () => {
   });
 
   test("method errors", () => {
-    // Test both normalItem and pairs cases.
     for (const start of [0, 5]) {
       const arr = SparseIndices.new();
       arr.set(start, 5);

--- a/test/sparse_indices.test.ts
+++ b/test/sparse_indices.test.ts
@@ -628,8 +628,8 @@ describe("SparseIndices", () => {
       SparseIndices.deserialize([3, 7, {}, 3, 1])
     );
 
-    assert.throws(() => SparseIndices.deserialize([3, 7, 0, 3, 1]));
-    assert.throws(() => SparseIndices.deserialize([3, 0, 2, 3, 1]));
+    assert.doesNotThrow(() => SparseIndices.deserialize([3, 7, 0, 3, 1]));
+    assert.doesNotThrow(() => SparseIndices.deserialize([3, 0, 2, 3, 1]));
 
     assert.doesNotThrow(() => SparseIndices.deserialize([]));
     assert.doesNotThrow(() => SparseIndices.deserialize([0, 7, 1]));

--- a/test/sparse_indices.test.ts
+++ b/test/sparse_indices.test.ts
@@ -267,12 +267,6 @@ class Checker {
         countBetween(this.values, 0, i),
         i < this.values.length && this.values[i] !== null,
       ]);
-      for (let j = i; j < this.values.length + 2; j++) {
-        assert.strictEqual(
-          this.arr.countBetween(i, j),
-          countBetween(this.values, i, j)
-        );
-      }
     }
 
     // Test newSlicer 10x with random slices.
@@ -543,17 +537,6 @@ describe("SparseIndices", () => {
 
       // Each error case should throw and not change the array.
       // Indices >= length should *not* throw errors.
-
-      // countBetween
-      for (const bad of [-1, 0.5, NaN]) {
-        assert.throws(() => arr.countBetween(bad, 3));
-      }
-      for (const bad of [-1, 0.5, NaN]) {
-        assert.throws(() => arr.countBetween(0, bad));
-      }
-      assert.throws(() => arr.countBetween(1, -3));
-      assert.doesNotThrow(() => arr.countBetween(15, 18));
-      assert.deepStrictEqual(arr.serialize(), initial);
 
       // countAt
       for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_indices.test.ts
+++ b/test/sparse_indices.test.ts
@@ -207,10 +207,6 @@ class Checker {
     }
     assert.strictEqual(nextEntry, keys.length);
 
-    // // Test fromKeys.
-    // const arr2 = SparseIndices.fromKeys(keys);
-    // check(arr2, this.values);
-
     // Test items.
     const items = [...this.arr.items()];
     let prevEnd = -1;
@@ -581,21 +577,6 @@ describe("SparseIndices", () => {
       assert.deepStrictEqual(arr.serialize(), initial);
     }
   });
-
-  // test("fromKeys errors", () => {
-  //   for (const bad of [-1, 0.5, NaN]) {
-  //     assert.throws(() => SparseIndices.fromKeys([bad]));
-  //     assert.throws(() => SparseIndices.fromKeys([0, bad]));
-  //   }
-
-  //   assert.throws(() => SparseIndices.fromKeys([0, 1, 1]));
-
-  //   assert.throws(() => SparseIndices.fromKeys([0, 2, 1]));
-
-  //   assert.doesNotThrow(() => SparseIndices.fromKeys([]));
-  //   assert.doesNotThrow(() => SparseIndices.fromKeys([1]));
-  //   assert.doesNotThrow(() => SparseIndices.fromKeys([1, 7, 1000]));
-  // });
 
   test("deserialize errors", () => {
     for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -652,13 +652,12 @@ describe("SparseString", () => {
       // @ts-expect-error
       SparseString.deserialize(["abc", 7, {}, 3, "m"])
     );
-    assert.throws(() => SparseString.deserialize(["abc", 7, 6, 3, "m"]));
-    assert.throws(() => SparseString.deserialize(["abc", 7, "x", "y", "m"]));
 
-    assert.throws(() => SparseString.deserialize([3, "abc", 7, "xy", "m"]));
-
-    assert.throws(() => SparseString.deserialize(["abc", 7, "", 3, "m"]));
-    assert.throws(() => SparseString.deserialize(["abc", 0, "xy", 3, "m"]));
+    assert.doesNotThrow(() => SparseString.deserialize(["abc", 7, 6, 3, "m"]));
+    assert.doesNotThrow(() => SparseString.deserialize(["abc", 7, "x", "y", "m"]));
+    assert.doesNotThrow(() => SparseString.deserialize([3, "abc", 7, "xy", "m"]));
+    assert.doesNotThrow(() => SparseString.deserialize(["abc", 7, "", 3, "m"]));
+    assert.doesNotThrow(() => SparseString.deserialize(["abc", 0, "xy", 3, "m"]));
 
     assert.doesNotThrow(() => SparseString.deserialize([]));
     assert.doesNotThrow(() => SparseString.deserialize(["", 7, "x"]));

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -277,10 +277,6 @@ class Checker<E extends object | never = never> {
     assert.strictEqual(nextEntry, entries.length);
     assert.strictEqual(nextEntry, keys.length);
 
-    // // Test fromEntries.
-    // const arr2 = SparseString.fromEntries(entries);
-    // check(arr2, this.values);
-
     // Test items.
     const items = [...this.arr.items()];
     let prevEnd = -1;
@@ -825,44 +821,6 @@ describe("SparseString", () => {
       assert.deepStrictEqual(arr.serialize(), initial);
     }
   });
-
-  // test("fromEntries errors", () => {
-  //   for (const bad of [-1, 0.5, NaN]) {
-  //     assert.throws(() => SparseString.fromEntries([[bad, "x"]]));
-  //     assert.throws(() =>
-  //       SparseString.fromEntries([
-  //         [0, "y"],
-  //         [bad, "x"],
-  //       ])
-  //     );
-  //   }
-
-  //   assert.throws(() =>
-  //     SparseString.fromEntries([
-  //       [0, "x"],
-  //       [1, "y"],
-  //       [1, "z"],
-  //     ])
-  //   );
-
-  //   assert.throws(() =>
-  //     SparseString.fromEntries([
-  //       [0, "x"],
-  //       [2, "y"],
-  //       [1, "z"],
-  //     ])
-  //   );
-
-  //   assert.doesNotThrow(() => SparseString.fromEntries([]));
-  //   assert.doesNotThrow(() => SparseString.fromEntries([[1, "x"]]));
-  //   assert.doesNotThrow(() =>
-  //     SparseString.fromEntries([
-  //       [1, "x"],
-  //       [7, "y"],
-  //       [1000, "z"],
-  //     ])
-  //   );
-  // });
 
   test("deserialize errors", () => {
     for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -92,6 +92,8 @@ function check<E extends object | never>(
   assert.strictEqual(arr.length, getPresentLength(state));
   assert.strictEqual(arr.length, getValuesLength(values));
 
+  assert.strictEqual(arr.isEmpty(), getValuesLength(values) === 0);
+
   // Queries should also work on indexes past the length.
   for (let i = 0; i < 10; i++) {
     assert.deepStrictEqual(arr.has(arr.length + i), false);
@@ -448,6 +450,35 @@ describe("SparseString", () => {
       if (i >= 20) checker.delete(i - 20, 1);
       if (i % 10 === 0) checker.testQueries(rng);
     }
+  });
+
+  test("untrimmed", () => {
+    // Deliberately create arrays whose internal representation is untrimmed
+    // (ends with a deleted node) and check that length, isEmpty,
+    // and the serialized form are unaffected.
+    const checker = new Checker<Embed>();
+
+    checker.set(0, ..."abcde");
+    checker.delete(0, 5);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], []);
+
+    checker.set(0, ..."abcde");
+    checker.delete(3, 2);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], ["abc"]);
+
+    checker.set(0, ..."abcde");
+    checker.delete(3, 5);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], ["abc"]);
+
+    checker.setEmbed(5, { a: "foo" });
+    checker.setEmbed(6, { b: "bar" });
+    checker.delete(6, 1);
+    checker.delete(5, 1);
+    checker.testQueries(rng);
+    assert.deepStrictEqual(checker.serialize()[0], ["abc"]);
   });
 
   describe("fuzz", () => {

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -208,9 +208,9 @@ class Checker {
     assert.strictEqual(nextEntry, entries.length);
     assert.strictEqual(nextEntry, keys.length);
 
-    // Test fromEntries.
-    const arr2 = SparseString.fromEntries(entries);
-    check(arr2, this.values);
+    // // Test fromEntries.
+    // const arr2 = SparseString.fromEntries(entries);
+    // check(arr2, this.values);
 
     // Test items.
     const items = [...this.arr.items()];
@@ -611,43 +611,43 @@ describe("SparseString", () => {
     }
   });
 
-  test("fromEntries errors", () => {
-    for (const bad of [-1, 0.5, NaN]) {
-      assert.throws(() => SparseString.fromEntries([[bad, "x"]]));
-      assert.throws(() =>
-        SparseString.fromEntries([
-          [0, "y"],
-          [bad, "x"],
-        ])
-      );
-    }
+  // test("fromEntries errors", () => {
+  //   for (const bad of [-1, 0.5, NaN]) {
+  //     assert.throws(() => SparseString.fromEntries([[bad, "x"]]));
+  //     assert.throws(() =>
+  //       SparseString.fromEntries([
+  //         [0, "y"],
+  //         [bad, "x"],
+  //       ])
+  //     );
+  //   }
 
-    assert.throws(() =>
-      SparseString.fromEntries([
-        [0, "x"],
-        [1, "y"],
-        [1, "z"],
-      ])
-    );
+  //   assert.throws(() =>
+  //     SparseString.fromEntries([
+  //       [0, "x"],
+  //       [1, "y"],
+  //       [1, "z"],
+  //     ])
+  //   );
 
-    assert.throws(() =>
-      SparseString.fromEntries([
-        [0, "x"],
-        [2, "y"],
-        [1, "z"],
-      ])
-    );
+  //   assert.throws(() =>
+  //     SparseString.fromEntries([
+  //       [0, "x"],
+  //       [2, "y"],
+  //       [1, "z"],
+  //     ])
+  //   );
 
-    assert.doesNotThrow(() => SparseString.fromEntries([]));
-    assert.doesNotThrow(() => SparseString.fromEntries([[1, "x"]]));
-    assert.doesNotThrow(() =>
-      SparseString.fromEntries([
-        [1, "x"],
-        [7, "y"],
-        [1000, "z"],
-      ])
-    );
-  });
+  //   assert.doesNotThrow(() => SparseString.fromEntries([]));
+  //   assert.doesNotThrow(() => SparseString.fromEntries([[1, "x"]]));
+  //   assert.doesNotThrow(() =>
+  //     SparseString.fromEntries([
+  //       [1, "x"],
+  //       [7, "y"],
+  //       [1000, "z"],
+  //     ])
+  //   );
+  // });
 
   test("deserialize errors", () => {
     for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -188,7 +188,7 @@ class Checker {
   }
 
   /**
-   * Test all _getAtCount inputs and some newSlicer walks.
+   * Test all indexOfCount inputs and some newSlicer walks.
    *
    * More expensive (O(length^2) ops), so only call occasionally,
    * in "interesting" states.
@@ -226,7 +226,7 @@ class Checker {
       prevEnd = index + values.length;
     }
 
-    // Test _getAtCount.
+    // Test indexOfCount.
     for (
       let startIndex = 0;
       startIndex < this.values.length + 2;
@@ -244,17 +244,9 @@ class Checker {
         }
         if (index >= this.values.length) {
           // count is too large - not found.
-          assert.deepStrictEqual(this.arr._getAtCount(count, startIndex), null);
           assert.strictEqual(this.arr.indexOfCount(count, startIndex), -1);
         } else {
           // Answer is index.
-          const actual = this.arr._getAtCount(count, startIndex);
-          assert.isNotNull(actual);
-          const [item, offset, actualIndex] = actual!;
-          assert.deepStrictEqual(
-            [item[offset], actualIndex],
-            [this.values[index], index]
-          );
           assert.strictEqual(this.arr.indexOfCount(count, startIndex), index);
         }
       }

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -655,7 +655,7 @@ describe("SparseString", () => {
     const ALL_LENGTH = 5;
     test(`all ${ALL_LENGTH}-length ops`, function () {
       // Generous timeout (5x what my laptop needs).
-      this.timeout(60000);
+      this.timeout(70000);
 
       // Generate each possible array outline of length <= ALL_LENGTH.
       for (let a = 0; a < Math.pow(3, ALL_LENGTH); a++) {
@@ -801,6 +801,10 @@ describe("SparseString", () => {
       }
       for (const bad of [-1, 0.5, NaN]) {
         assert.throws(() => arr.delete(3, bad));
+      }
+      for (const badValue of [null, () => {}, 3]) {
+        // @ts-expect-error
+        assert.throws(() => arr.set(0, badValue));
       }
       assert.doesNotThrow(() => arr.clone().set(15, "abc"));
       assert.doesNotThrow(() => arr.clone().delete(15, 3));

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -3,8 +3,7 @@ import { describe, test } from "mocha";
 import seedrandom from "seedrandom";
 import { SerializedSparseString, SparseString } from "../src";
 import { DeletedNode, Node } from "../src/sparse_items";
-
-const DEBUG = false;
+import { DEBUG } from "./util";
 
 // TODO: embed tests.
 
@@ -39,16 +38,15 @@ function validate(nodes: Node<string>[]): void {
       nodes[i + 1].constructor.name
     );
   }
-
-  // Last node is not deleted.
-  if (nodes.length !== 0) {
-    assert.isFalse(nodes[nodes.length - 1] instanceof DeletedNode);
-  }
 }
 
 function getPresentLength(nodes: Node<string>[]): number {
   let length = 0;
   for (const node of nodes) length += node.length;
+  // Handle untrimmed case.
+  if (nodes.length !== 0 && nodes[nodes.length - 1] instanceof DeletedNode) {
+    length -= nodes[nodes.length - 1].length;
+  }
   return length;
 }
 

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -517,7 +517,7 @@ describe("SparseString", () => {
     assert.deepStrictEqual(arr.serialize(), []);
 
     arr.set(5, "cd");
-    assert.deepStrictEqual(arr.serialize(), ["", 5, "cd"]);
+    assert.deepStrictEqual(arr.serialize(), [5, "cd"]);
 
     arr.delete(0, 10);
     assert.deepStrictEqual(arr.serialize(), []);
@@ -636,13 +636,14 @@ describe("SparseString", () => {
       assert.throws(() => SparseString.deserialize(["abc", 7, "xy", bad, "m"]));
     }
 
+    // Note: objects including arrays are okay (no error) because they become embeds.
     assert.throws(() =>
       // @ts-expect-error
-      SparseString.deserialize(["abc", 7, ["x", "y", "z"], 3, "m"])
+      SparseString.deserialize(["abc", 7, undefined, 3, "m"])
     );
     assert.throws(() =>
       // @ts-expect-error
-      SparseString.deserialize([["x", "y", "z"], 7, "abc", 3, "m"])
+      SparseString.deserialize([Symbol(), 7, "abc", 3, "m"])
     );
     assert.throws(() =>
       // @ts-expect-error
@@ -650,14 +651,20 @@ describe("SparseString", () => {
     );
     assert.throws(() =>
       // @ts-expect-error
-      SparseString.deserialize(["abc", 7, {}, 3, "m"])
+      SparseString.deserialize(["abc", 7, () => {}, 3, "m"])
     );
 
     assert.doesNotThrow(() => SparseString.deserialize(["abc", 7, 6, 3, "m"]));
-    assert.doesNotThrow(() => SparseString.deserialize(["abc", 7, "x", "y", "m"]));
-    assert.doesNotThrow(() => SparseString.deserialize([3, "abc", 7, "xy", "m"]));
+    assert.doesNotThrow(() =>
+      SparseString.deserialize(["abc", 7, "x", "y", "m"])
+    );
+    assert.doesNotThrow(() =>
+      SparseString.deserialize([3, "abc", 7, "xy", "m"])
+    );
     assert.doesNotThrow(() => SparseString.deserialize(["abc", 7, "", 3, "m"]));
-    assert.doesNotThrow(() => SparseString.deserialize(["abc", 0, "xy", 3, "m"]));
+    assert.doesNotThrow(() =>
+      SparseString.deserialize(["abc", 0, "xy", 3, "m"])
+    );
 
     assert.doesNotThrow(() => SparseString.deserialize([]));
     assert.doesNotThrow(() => SparseString.deserialize(["", 7, "x"]));

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -2,13 +2,19 @@ import { assert } from "chai";
 import { describe, test } from "mocha";
 import seedrandom from "seedrandom";
 import { SerializedSparseString, SparseString } from "../src";
-import { Pair } from "../src/sparse_items";
+import { DeletedNode } from "../src/sparse_items";
 
 const DEBUG = false;
 
-function getState(arr: SparseString): Pair<string>[] {
-  // @ts-expect-error Ignore protected
-  return arr.asPairs();
+// TODO: embed tests.
+
+function getState(arr: SparseString): unknown[] {
+  const nodes: unknown[] = [];
+  // @ts-expect-error Ignore private.
+  for (let current = arr.next; current !== null; current = current.next) {
+    nodes.push(current instanceof DeletedNode ? -current.length : current.item);
+  }
+  return nodes;
 }
 
 function validate(pairs: Pair<string>[]): void {

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -269,12 +269,6 @@ class Checker {
         countBetween(this.values, 0, i),
         i < this.values.length && this.values[i] !== null,
       ]);
-      for (let j = i; j < this.values.length + 2; j++) {
-        assert.strictEqual(
-          this.arr.countBetween(i, j),
-          countBetween(this.values, i, j)
-        );
-      }
     }
 
     // Test newSlicer 10x with random slices.
@@ -545,17 +539,6 @@ describe("SparseString", () => {
 
       // Each error case should throw and not change the array.
       // Indices >= length should *not* throw errors.
-
-      // countBetween
-      for (const bad of [-1, 0.5, NaN]) {
-        assert.throws(() => arr.countBetween(bad, 3));
-      }
-      for (const bad of [-1, 0.5, NaN]) {
-        assert.throws(() => arr.countBetween(0, bad));
-      }
-      assert.throws(() => arr.countBetween(1, -3));
-      assert.doesNotThrow(() => arr.countBetween(15, 18));
-      assert.deepStrictEqual(arr.serialize(), initial);
 
       // countAt
       for (const bad of [-1, 0.5, NaN]) {

--- a/test/sparse_string.test.ts
+++ b/test/sparse_string.test.ts
@@ -728,7 +728,6 @@ describe("SparseString", () => {
   });
 
   test("toString", () => {
-    // Test both normalItem and pairs cases.
     for (const start of [0, 5]) {
       const arr = SparseString.new();
       arr.set(start, "abcde");
@@ -740,10 +739,9 @@ describe("SparseString", () => {
   });
 
   test("clone", () => {
-    // Test both normalItem and pairs cases.
-    for (const start of [0, 5]) {
+    for (const start of [null, 0, 5]) {
       const arr = SparseString.new();
-      arr.set(start, "abcde");
+      if (start !== null) arr.set(start, "abcde");
       const cloned = arr.clone();
 
       const clonedSerialized = cloned.serialize();
@@ -786,7 +784,6 @@ describe("SparseString", () => {
   });
 
   test("method errors", () => {
-    // Test both normalItem and pairs cases.
     for (const start of [0, 5]) {
       const arr = SparseString.new();
       arr.set(start, "abcde");

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,1 @@
+export const DEBUG = process.env.DEBUG === "true";


### PR DESCRIPTION
Refactor internals to use a singly linked list of nodes, where each node is either an item (contiguous present values) or a number of deleted values.

This requires less complex code to update, and it also makes it possible to have adjacent present items. The latter are used to implement SparseString "embeds": object values mixed in with the chars. Each embed gets its own item, which may be adjacent to a string item or another embed - something that the previous internals could not support.